### PR TITLE
chore(terraform): update module versions for gcs and iam to latest releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Truefoundry Google Cloud Control Plane Module
 |------|--------|---------|
 | <a name="module_postgresql-db"></a> [postgresql-db](#module\_postgresql-db) | GoogleCloudPlatform/sql-db/google//modules/postgresql | 23.0.0 |
 | <a name="module_service_account_iam_bindings"></a> [service\_account\_iam\_bindings](#module\_service\_account\_iam\_bindings) | terraform-google-modules/iam/google//modules/service_accounts_iam | 8.0.0 |
-| <a name="module_service_accounts"></a> [service\_accounts](#module\_service\_accounts) | terraform-google-modules/service-accounts/google | 4.4.1 |
-| <a name="module_truefoundry_gcs"></a> [truefoundry\_gcs](#module\_truefoundry\_gcs) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 8.0.1 |
+| <a name="module_service_accounts"></a> [service\_accounts](#module\_service\_accounts) | terraform-google-modules/service-accounts/google | 4.5.0 |
+| <a name="module_truefoundry_gcs"></a> [truefoundry\_gcs](#module\_truefoundry\_gcs) | terraform-google-modules/cloud-storage/google//modules/simple_bucket | 9.1.0 |
 
 ## Resources
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Truefoundry Google Cloud Control Plane Module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.4 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.11 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 6.21 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.6 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.11 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 6.21 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.6 |
 
 ## Modules

--- a/gcs.tf
+++ b/gcs.tf
@@ -1,7 +1,7 @@
 module "truefoundry_gcs" {
   count                    = var.truefoundry_gcs_enabled ? 1 : 0
   source                   = "terraform-google-modules/cloud-storage/google//modules/simple_bucket"
-  version                  = "8.0.1"
+  version                  = "9.1.0"
   project_id               = var.project_id
   name                     = local.truefoundry_blob_storage_name
   location                 = var.region

--- a/iam.tf
+++ b/iam.tf
@@ -1,6 +1,6 @@
 module "service_accounts" {
   source        = "terraform-google-modules/service-accounts/google"
-  version       = "4.4.1"
+  version       = "4.5.0"
   project_id    = var.project_id
   names         = [local.serviceaccount_name]
   descriptions  = ["Truefoundry serviceaccount for truefoundry control-plane components"]

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 6.11"
+      version = "~> 6.21"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Upgrade `truefoundry_gcs` module to version 9.1.0 and `service_accounts`
module to version 4.5.0 to incorporate latest features and bug fixes.
