### PR TITLE
fix(terraform): enable GCS bucket creation by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Truefoundry Google Cloud Control Plane Module
 | <a name="input_truefoundry_gcs_enabled"></a> [truefoundry\_gcs\_enabled](#input\_truefoundry\_gcs\_enabled) | Enable creation of GCS bucket | `bool` | `true` | no |
 | <a name="input_truefoundry_gcs_force_destroy"></a> [truefoundry\_gcs\_force\_destroy](#input\_truefoundry\_gcs\_force\_destroy) | Enable force destroy on GCS bucket | `bool` | `true` | no |
 | <a name="input_truefoundry_gcs_override_name"></a> [truefoundry\_gcs\_override\_name](#input\_truefoundry\_gcs\_override\_name) | Override name for GCS bucket. truefoundry\_gcs\_enable\_override must be set true | `string` | `""` | no |
+| <a name="input_truefoundry_k8s_namespace"></a> [truefoundry\_k8s\_namespace](#input\_truefoundry\_k8s\_namespace) | The k8s truefoundry namespace | `string` | `"truefoundry"` | no |
+| <a name="input_truefoundry_k8s_service_account"></a> [truefoundry\_k8s\_service\_account](#input\_truefoundry\_k8s\_service\_account) | The k8s truefoundry service account name | `string` | `"truefoundry"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the network VPC | `string` | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Truefoundry Google Cloud Control Plane Module
 | <a name="input_truefoundry_db_zone"></a> [truefoundry\_db\_zone](#input\_truefoundry\_db\_zone) | Zone for SQL DB - This must match the region | `string` | `""` | no |
 | <a name="input_truefoundry_gcs_cors_origins"></a> [truefoundry\_gcs\_cors\_origins](#input\_truefoundry\_gcs\_cors\_origins) | Allowed CORS origin for GCS bucket | `list(string)` | <pre>[<br/>  "*"<br/>]</pre> | no |
 | <a name="input_truefoundry_gcs_enable_override"></a> [truefoundry\_gcs\_enable\_override](#input\_truefoundry\_gcs\_enable\_override) | Enable override for GCS bucket name. You must pass truefoundry\_gcs\_override\_name | `bool` | `false` | no |
-| <a name="input_truefoundry_gcs_enabled"></a> [truefoundry\_gcs\_enabled](#input\_truefoundry\_gcs\_enabled) | Enable creation of GCS bucket | `bool` | `false` | no |
+| <a name="input_truefoundry_gcs_enabled"></a> [truefoundry\_gcs\_enabled](#input\_truefoundry\_gcs\_enabled) | Enable creation of GCS bucket | `bool` | `true` | no |
 | <a name="input_truefoundry_gcs_force_destroy"></a> [truefoundry\_gcs\_force\_destroy](#input\_truefoundry\_gcs\_force\_destroy) | Enable force destroy on GCS bucket | `bool` | `true` | no |
 | <a name="input_truefoundry_gcs_override_name"></a> [truefoundry\_gcs\_override\_name](#input\_truefoundry\_gcs\_override\_name) | Override name for GCS bucket. truefoundry\_gcs\_enable\_override must be set true | `string` | `""` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the network VPC | `string` | n/a | yes |

--- a/iam.tf
+++ b/iam.tf
@@ -20,6 +20,7 @@ module "service_account_iam_bindings" {
     "roles/iam.workloadIdentityUser" = [
       "serviceAccount:${var.project_id}.svc.id.goog[${var.svcfoundry_k8s_namespace}/${var.svcfoundry_k8s_service_account}]",
       "serviceAccount:${var.project_id}.svc.id.goog[${var.mlfoundry_k8s_namespace}/${var.mlfoundry_k8s_service_account}]",
+      "serviceAccount:${var.project_id}.svc.id.goog[${var.truefoundry_k8s_namespace}/${var.truefoundry_k8s_service_account}]",
     ]
   }
 }

--- a/output.tf
+++ b/output.tf
@@ -27,7 +27,7 @@ output "serviceaccount_iam_email" {
 }
 
 output "serviceaccount_detail" {
-  value       = module.service_accounts.service_account
+  value       = jsonencode(module.service_accounts.service_account)
   description = "Serviceaccount details"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -186,7 +186,7 @@ variable "svcfoundry_k8s_namespace" {
 variable "truefoundry_gcs_enabled" {
   description = "Enable creation of GCS bucket"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "truefoundry_gcs_enable_override" {

--- a/variables.tf
+++ b/variables.tf
@@ -188,6 +188,17 @@ variable "truefoundry_gcs_enabled" {
   type        = bool
   default     = true
 }
+variable "truefoundry_k8s_namespace" {
+  description = "The k8s truefoundry namespace"
+  type        = string
+  default     = "truefoundry"
+}
+
+variable "truefoundry_k8s_service_account" {
+  description = "The k8s truefoundry service account name"
+  type        = string
+  default     = "truefoundry"
+}
 
 variable "truefoundry_gcs_enable_override" {
   description = "Enable override for GCS bucket name. You must pass truefoundry_gcs_override_name"


### PR DESCRIPTION
Set the default value of the truefoundry_gcs_enabled variable to true, allowing for automatic creation of the GCS bucket.
